### PR TITLE
Fix clash with js-dossier

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,11 @@ task :chrome do
     f.puts file
   end
   puts '+ chrome/nice_alert.js'.green
+  file = JSPP 'src/chrome_content_script.js'
+  File.open 'chrome/content_script.js', 'w' do |f|
+    f.puts file
+  end
+  puts '+ chrome/content_script.js'.green
 end
 
 task :safari do

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,4 +1,5 @@
 {
+  "manifest_version": 2,
   "name": "Nice alert",
   "version": "1.3.1",
   "description": "Makes alert box suck less",

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -11,9 +11,10 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["nice_alert.js"],
+      "js": ["content_script.js"],
       "run_at": "document_start"
     }
   ],
+  "web_accessible_resources": ["nice_alert.js"],
   "update_url": "http://clients2.google.com/service/update2/crx"
 }

--- a/src/chrome.js
+++ b/src/chrome.js
@@ -1,13 +1,3 @@
-function main() {
-
 var w = window;
 
 /*> nice_alert.js */
-
-}
-
-if (!document.xmlVersion) {
-	var script = document.createElement('script');
-	script.appendChild(document.createTextNode('('+ main +')();'));
-	document.documentElement.appendChild(script);
-}

--- a/src/chrome_content_script.js
+++ b/src/chrome_content_script.js
@@ -1,0 +1,8 @@
+if (!document.xmlVersion) {
+    var script = document.createElement('script');
+    script.src = chrome.extension.getURL('nice_alert.js');
+    script.onload = function() {
+        this.parentNode.removeChild(this);
+    };
+    (document.head||document.documentElement).appendChild(script);
+}


### PR DESCRIPTION
js-dossier fails if nice-alert.js inserts its code on a page.

Fix it by ensuring extension's <script> is removed after execution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nv/nice-alert.js/10)
<!-- Reviewable:end -->
